### PR TITLE
STAR-79: Add fake funding rate historical data

### DIFF
--- a/src/bonsai/rest/funding.ts
+++ b/src/bonsai/rest/funding.ts
@@ -42,7 +42,9 @@ export const useCurrentMarketHistoricalFunding = (): Loadable<HistoricalFundingO
       const result: IndexerHistoricalFundingResponse =
         await indexerClient.markets.getPerpetualMarketHistoricalFunding(currentMarketId);
 
-      return result.historicalFunding.reverse().map(mapFundingChartObject);
+      const transformedData = result.historicalFunding.map(mapFundingChartObject);
+
+      return transformedData;
     }, 'currentMarketHistoricalFunding'),
     refetchInterval: timeUnits.hour,
     staleTime: timeUnits.hour,

--- a/ts-sdk/src/clients/modules/markets.ts
+++ b/ts-sdk/src/clients/modules/markets.ts
@@ -1,3 +1,4 @@
+import { generateFakeHistoricalFunding } from '../../utils/fakeDataGenerators';
 import { TimePeriod } from '../constants';
 import { Data } from '../types';
 import RestClient from './rest';
@@ -6,80 +7,90 @@ import RestClient from './rest';
  * @description REST endpoints for data unrelated to a particular address.
  */
 export default class MarketsClient extends RestClient {
-    async getPerpetualMarkets(market?: string): Promise<Data> {
-        const uri = '/v4/perpetualMarkets';
-        // return this.get(uri, { ticker: "MIRG.BA-USD" });
+  async getPerpetualMarkets(market?: string): Promise<Data> {
+    const uri = '/v4/perpetualMarkets';
+    // return this.get(uri, { ticker: "MIRG.BA-USD" });
 
-        // Load emerging markets data from JSON file
-        try {
-            const response = await fetch('/emerging_markets.json');
-            if (!response.ok) {
-                throw new Error(`Failed to fetch emerging markets: ${response.status}`);
-            }
-            const emergingMarkets = await response.json();
-            return emergingMarkets;
-        } catch (error) {
-            console.error('Error loading emerging markets:', error);
-            // Fallback to empty markets if JSON loading fails
-            return { markets: {} };
-        }
+    // Load emerging markets data from JSON file
+    try {
+      const response = await fetch('/emerging_markets.json');
+      if (!response.ok) {
+        throw new Error(`Failed to fetch emerging markets: ${response.status}`);
+      }
+      const emergingMarkets = await response.json();
+      return emergingMarkets;
+    } catch (error) {
+      console.error('Error loading emerging markets:', error);
+      // Fallback to empty markets if JSON loading fails
+      return { markets: {} };
     }
+  }
 
-    async getPerpetualMarketOrderbook(market: string): Promise<Data> {
-        const uri = `/v4/orderbooks/perpetualMarket/${market}`;
-        return this.get(uri);
-    }
+  async getPerpetualMarketOrderbook(market: string): Promise<Data> {
+    const uri = `/v4/orderbooks/perpetualMarket/${market}`;
+    return this.get(uri);
+  }
 
-    async getPerpetualMarketTrades(
-        market: string,
-        startingBeforeOrAtHeight?: number | null,
-        startingBeforeOrAt?: string | null,
-        limit?: number | null,
-        page?: number | null,
-    ): Promise<Data> {
-        const uri = `/v4/trades/perpetualMarket/${market}`;
-        return this.get(uri, {
-            createdBeforeOrAtHeight: startingBeforeOrAtHeight,
-            createdBeforeOrAt: startingBeforeOrAt,
-            limit,
-            page,
-        });
-    }
+  async getPerpetualMarketTrades(
+    market: string,
+    startingBeforeOrAtHeight?: number | null,
+    startingBeforeOrAt?: string | null,
+    limit?: number | null,
+    page?: number | null,
+  ): Promise<Data> {
+    const uri = `/v4/trades/perpetualMarket/${market}`;
+    return this.get(uri, {
+      createdBeforeOrAtHeight: startingBeforeOrAtHeight,
+      createdBeforeOrAt: startingBeforeOrAt,
+      limit,
+      page,
+    });
+  }
 
-    async getPerpetualMarketCandles(
-        market: string,
-        resolution: string,
-        fromISO?: string | null,
-        toISO?: string | null,
-        limit?: number | null,
-    ): Promise<Data> {
-        const uri = `/v4/candles/perpetualMarkets/${market}`;
-        return this.get(uri, {
-            resolution,
-            fromISO,
-            toISO,
-            limit,
-        });
-    }
+  async getPerpetualMarketCandles(
+    market: string,
+    resolution: string,
+    fromISO?: string | null,
+    toISO?: string | null,
+    limit?: number | null,
+  ): Promise<Data> {
+    const uri = `/v4/candles/perpetualMarkets/${market}`;
+    return this.get(uri, {
+      resolution,
+      fromISO,
+      toISO,
+      limit,
+    });
+  }
 
-    async getPerpetualMarketHistoricalFunding(
-        market: string,
-        effectiveBeforeOrAt?: string | null,
-        effectiveBeforeOrAtHeight?: number | null,
-        limit?: number | null,
-    ): Promise<Data> {
-        const uri = `/v4/historicalFunding/${market}`;
-        return this.get(uri, {
-            effectiveBeforeOrAt,
-            effectiveBeforeOrAtHeight,
-            limit,
-        });
-    }
+  async getPerpetualMarketHistoricalFunding(
+    market: string,
+    effectiveBeforeOrAt?: string | null,
+    effectiveBeforeOrAtHeight?: number | null,
+    limit?: number | null,
+  ): Promise<Data> {
 
-    async getPerpetualMarketSparklines(period: string = TimePeriod.ONE_DAY): Promise<Data> {
-        const uri = '/v4/sparklines';
-        return this.get(uri, {
-            timePeriod: period,
-        });
+    const { historicalFunding } = generateFakeHistoricalFunding(market, undefined);
+    const cutoffTime = effectiveBeforeOrAt ? Date.parse(effectiveBeforeOrAt) : undefined;
+    const cutoffHeight = effectiveBeforeOrAtHeight ?? undefined;
+
+    let data = historicalFunding;
+    if (cutoffTime != null) {
+      data = data.filter((d: { effectiveAt: string; }) => Date.parse(d.effectiveAt) <= cutoffTime);
+    } else if (cutoffHeight != null) {
+      const h = Number(cutoffHeight);
+      data = data.filter((d: { effectiveAtHeight: any; }) => Number(d.effectiveAtHeight) <= h);
     }
+    if (limit && limit > 0) {
+      data = data.slice(-limit); // most recent N
+    }
+    return { historicalFunding: data };
+  }
+
+  async getPerpetualMarketSparklines(period: string = TimePeriod.ONE_DAY): Promise<Data> {
+    const uri = '/v4/sparklines';
+    return this.get(uri, {
+      timePeriod: period,
+    });
+  }
 }

--- a/ts-sdk/src/utils/fakeDataGenerators.ts
+++ b/ts-sdk/src/utils/fakeDataGenerators.ts
@@ -1,0 +1,86 @@
+import { Data } from '../types';
+
+/**
+ * Generates realistic fake historical funding data for testing purposes
+ * Creates 168 hours (1 week) of hourly funding rate data with realistic market volatility
+ */
+export const generateFakeHistoricalFunding = (market: string, limit?: number | null): Data => {
+  const now = new Date();
+  const data: any[] = [];
+
+  // Generate data for the last 168 hours (1 week) with hourly intervals
+  for (let i = 167; i >= 0; i--) {
+    // Create timestamp that goes back exactly i hours from now
+    // This ensures we get proper time distribution across days
+    const timestamp = new Date(now.getTime() - (i * 60 * 60 * 1000));
+
+    // Ensure the timestamp is properly set to the hour (remove minutes/seconds)
+    timestamp.setMinutes(0, 0, 0);
+
+    // Generate realistic, volatile funding rates with much wider range
+    // Start with a base rate and add realistic market volatility
+    let rate: number;
+
+    // Use a random walk approach for more realistic market behavior
+    if (i === 167) { // First period - start with a random rate
+      rate = (Math.random() - 0.5) * 0.01; // Start between -0.5% and +0.5%
+    } else {
+      // Get the previous rate and add random movement
+      const prevRate = data[data.length - 1].rate;
+      const prevRateNum = parseFloat(prevRate);
+
+      // Add random walk with mean reversion tendency - make steps much larger
+      const randomStep = (Math.random() - 0.5) * 0.008; // ±0.4% step (much larger!)
+      const meanReversion = -prevRateNum * 0.1; // Tendency to revert to zero
+      rate = prevRateNum + randomStep + meanReversion;
+    }
+
+    // Add occasional market stress events (larger movements)
+    if (Math.random() < 0.2) { // 20% chance of stress event
+      rate += (Math.random() - 0.5) * 0.01; // ±0.5% stress movement
+    }
+
+    // Add weekly patterns (weekend vs weekday volatility)
+    const dayOfWeek = timestamp.getDay();
+    if (dayOfWeek === 0 || dayOfWeek === 6) { // Weekend
+      rate *= 1.8; // Higher volatility on weekends
+    }
+
+    // Ensure rates stay within realistic bounds for most markets
+    rate = Math.max(-0.005, Math.min(0.005, rate)); // Cap at ±0.5%
+
+    // Generate realistic BTC price based on the example range
+    let basePrice: number;
+    if (market.includes('BTC')) {
+      basePrice = 112000 + (Math.random() - 0.5) * 4000; // $110k-$114k range like example
+    } else if (market.includes('ETH')) {
+      basePrice = 3000 + (Math.random() - 0.5) * 200; // $2.9k-$3.1k range
+    } else if (market.includes('SOL')) {
+      basePrice = 80 + (Math.random() - 0.5) * 20; // $70-$90 range
+    } else {
+      basePrice = 100 + (Math.random() - 0.5) * 50; // Generic $75-$125 range
+    }
+
+    // Add some price volatility
+    const priceChange = (Math.random() - 0.5) * 0.02; // ±1% change
+    const price = basePrice * (1 + priceChange);
+
+    // Generate block height (incrementing by roughly 1 hour worth of blocks)
+    const blockHeight = 53661860 - (i * 3600); // Starting from example height, decrementing hourly
+
+    data.push({
+      ticker: market,
+      rate: rate.toFixed(9), // 9 decimal places to match example precision
+      price: price.toFixed(2),
+      effectiveAt: timestamp.toISOString(),
+      effectiveAtHeight: blockHeight.toString(),
+    });
+  }
+
+  // Apply limit if specified
+  if (limit && limit > 0) {
+    return { historicalFunding: data.slice(-limit) };
+  }
+
+  return { historicalFunding: data };
+};


### PR DESCRIPTION
Added fake funding rate data to the sdk.

Instead of fetching from the indexer we generate some realistic looking data.

<img width="1597" height="832" alt="image" src="https://github.com/user-attachments/assets/cae4dd81-4e41-4859-b366-0204c70a8183" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Emerging markets loaded from bundled data.
  - Historical funding is now generated locally per market with optional time/height filtering and limit.

- Bug Fixes
  - Funding history displays in correct chronological order.
  - Prevents unintended modification of underlying funding datasets during processing.

- Reliability
  - Improved error handling when loading market data, returning a safe empty result on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->