### PR TITLE
Add basic starboard i18n support

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apollo/server": "^4.9.5",
-        "@subsquid/big-decimal": "^1.0.0",
+    "@subsquid/big-decimal": "^1.0.0",
     "@apollo/subgraph": "^2.5.5",
     "@subsquid/batch-processor": "^0.0.0",
     "@subsquid/fuel-objects": "^0.0.4",

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -31,14 +31,16 @@ export enum SupportedLocales {
   DE = 'de',
 }
 
+export const STARBOARD_STRING_KEYS = {
+  FUEL_WALLET: 'FUEL_WALLET',
+};
+
 export const STRING_KEYS = {
   ...APP_STRING_KEYS,
   ...ERRORS_STRING_KEYS,
   ...WARNINGS_STRING_KEYS,
   ...NOTIFICATIONS_STRING_KEYS,
-  STARBOARD_STRING_KEYS: {
-   FUEL_WALLET: "Fuel Wallet"
-  }
+  ...STARBOARD_STRING_KEYS,
 };
 
 export const STRING_KEY_VALUES = Object.fromEntries(
@@ -56,15 +58,15 @@ export type StringGetterParams = Record<string, any>;
 
 export type StringGetterProps<T extends StringGetterParams> =
   | {
-    key: string;
-    params?: T;
-    fallback?: string;
-  }
+      key: string;
+      params?: T;
+      fallback?: string;
+    }
   | {
-    key?: Nullable<string>;
-    params?: T;
-    fallback: string;
-  };
+      key?: Nullable<string>;
+      params?: T;
+      fallback: string;
+    };
 
 export type StringGetterFunction = <T extends StringGetterParams>(
   props: StringGetterProps<T>

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -58,12 +58,12 @@ export type StringGetterParams = Record<string, any>;
 
 export type StringGetterProps<T extends StringGetterParams> =
   | {
-      key: string;
+      key: StringKey;
       params?: T;
       fallback?: string;
     }
   | {
-      key?: Nullable<string>;
+      key?: Nullable<StringKey>;
       params?: T;
       fallback: string;
     };

--- a/src/constants/localization.ts
+++ b/src/constants/localization.ts
@@ -33,7 +33,7 @@ export enum SupportedLocales {
 
 export const STARBOARD_STRING_KEYS = {
   FUEL_WALLET: 'FUEL_WALLET',
-};
+} as const;
 
 export const STRING_KEYS = {
   ...APP_STRING_KEYS,

--- a/src/constants/wallets.ts
+++ b/src/constants/wallets.ts
@@ -7,12 +7,12 @@ import { STRING_KEYS } from '@/constants/localization';
 import {
   CoinbaseIcon,
   EmailIcon,
+  FuelWalletIcon,
   GenericWalletIcon,
   KeplrIcon,
   MetaMaskIcon,
   OkxWalletIcon,
   PhantomIcon,
-  FuelWalletIcon,
   WalletConnectIcon,
 } from '@/icons';
 
@@ -160,7 +160,7 @@ export const wallets = {
   },
   [WalletType.FuelWallet]: {
     type: WalletType.FuelWallet,
-    // stringKey: STRING_KEYS.STARBOARD_STRING_KEYS.FUEL_WALLET,
+    stringKey: STRING_KEYS.FUEL_WALLET,
     icon: FuelWalletIcon,
   },
 } satisfies Record<WalletInfo['name'], WalletConfig>;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "FUEL_WALLET": "Fuel Wallet"
+}

--- a/src/state/localizationMiddleware.ts
+++ b/src/state/localizationMiddleware.ts
@@ -1,3 +1,4 @@
+import STARBOARD_EN from '@/i18n/en.json';
 import { type SupportedLocale } from '@dydxprotocol/v4-localization';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { mapValues } from 'lodash';
@@ -19,17 +20,23 @@ import { getBrowserLanguage } from '@/lib/language';
 import { getLocalStorage, setLocalStorage } from '@/lib/localStorage';
 import { objectKeys } from '@/lib/objectHelpers';
 
+// NOTE: We might want to include more locales in the future
+// for now we'll just use EN
+const STARBOARD_LOCALES = {
+  [SupportedLocales.EN]: STARBOARD_EN,
+} as Record<SupportedLocale, any>;
+
 const allLocalesPromise = calc(async () => {
   const { LOCALE_DATA, NOTIFICATIONS, TOOLTIPS } = await import('@dydxprotocol/v4-localization');
-  return mapValues(
-    SUPPORTED_LOCALE_MAP,
-    (obj, locale) =>
-      ({
-        ...LOCALE_DATA[locale as SupportedLocale],
-        ...NOTIFICATIONS[locale as SupportedLocale],
-        TOOLTIPS: TOOLTIPS[locale as SupportedLocale],
-      }) as LocaleData
-  );
+  return mapValues(SUPPORTED_LOCALE_MAP, (obj, locale) => {
+    const STARBOARD_LOCALE = STARBOARD_LOCALES[locale as SupportedLocale] ?? {};
+    return {
+      ...LOCALE_DATA[locale as SupportedLocale],
+      ...NOTIFICATIONS[locale as SupportedLocale],
+      TOOLTIPS: TOOLTIPS[locale as SupportedLocale],
+      ...STARBOARD_LOCALE,
+    } as LocaleData;
+  });
 });
 
 let currentSetLocaleId = 0;

--- a/src/state/localizationMiddleware.ts
+++ b/src/state/localizationMiddleware.ts
@@ -7,6 +7,7 @@ import { LocalStorageKey } from '@/constants/localStorage';
 import {
   EU_LOCALES,
   LocaleData,
+  STARBOARD_STRING_KEYS,
   SUPPORTED_LOCALE_MAP,
   SUPPORTED_LOCALES,
   SupportedLocales,
@@ -22,9 +23,10 @@ import { objectKeys } from '@/lib/objectHelpers';
 
 // NOTE: We might want to include more locales in the future
 // for now we'll just use EN
-const STARBOARD_LOCALES = {
-  [SupportedLocales.EN]: STARBOARD_EN,
-} as Record<SupportedLocale, any>;
+type StarboardLocale = Partial<Record<keyof typeof STARBOARD_STRING_KEYS, string>>;
+const STARBOARD_LOCALES: Partial<Record<SupportedLocale, StarboardLocale>> = {
+  [SupportedLocales.EN]: STARBOARD_EN as StarboardLocale,
+};
 
 const allLocalesPromise = calc(async () => {
   const { LOCALE_DATA, NOTIFICATIONS, TOOLTIPS } = await import('@dydxprotocol/v4-localization');


### PR DESCRIPTION
## TL;DR

Allows to define our own locale data by following dydx's existent logic.

## Example with Fuel Wallet label

<img width="960" height="810" alt="image" src="https://github.com/user-attachments/assets/c55da4fb-3089-4e50-905b-43d0a8bf0f00" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added English translation for "Fuel Wallet".
  - Integrated STARBOARD locale resources into app localization, enabling locale-specific overrides (starting with English).
  - Wallet list now displays Fuel Wallet using the new localization key.

- Refactor
  - Flattened localization keys for consistency across the app.

- Chores
  - Minor indentation/formatting adjustment in package metadata.
  - Cleaned up wallet icon import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->