### PR TITLE
[STAR-283] ci: Allow ticket numbers in PR titles

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+    types: ["opened", "edited", "reopened", "synchronize"]
 
 jobs:
   lint:
@@ -25,9 +25,11 @@ jobs:
 
       - name: Lint PR Title
         run: |
-          echo "${PR_TITLE}" | pnpx commitlint --config commitlint.config.ts
+          echo "$PR_TITLE" \
+          | sed -E 's/^\[[A-Za-z0-9_-]+-[0-9]+\][[:space:]]*//' \
+          | pnpx commitlint --config commitlint.config.ts
         env:
-          PR_TITLE: '${{ github.event.pull_request.title }}'
+          PR_TITLE: "${{ github.event.pull_request.title }}"
 
       - name: ESLint
         run: |


### PR DESCRIPTION
## Description

Allows Jira ticket numbers in the title of PRs.

Changes
- Parse out jira ticket number before running commitlint

Example
- [STAR-283] ci(lint): Allow jir ticket numbers in PR titles.

## Limitations
Lint fails at ESLint step

[STAR-283]: https://charthouse.atlassian.net/browse/STAR-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved pull request title linting to automatically ignore leading ticket prefixes (e.g., “[ABC-123]”), ensuring consistent PR title formatting across the project.
  - Standardized workflow configuration strings for consistency and reliability in CI processes.
  - No user-facing changes; these updates streamline internal contribution workflows and maintainers’ review experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->